### PR TITLE
Fixes #30792 - Added root pw for image based deploy

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -31,6 +31,11 @@ oses:
 /bin/hostname  <%= @host.shortname %>.<%= @host.domain %>
 <% end -%>
 
+<% if @host.provision_method == 'image' && root_pass.present? -%>
+# Install the root password
+echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
+<% end -%>
+
 <%= snippet_if_exists(template_name + " custom snippet") %>
 <% if host_enc['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
 <%= snippet 'freeipa_register' %>


### PR DESCRIPTION
When deploying an Ubuntu/Debian host using the image-based deployment the root password is not set/changed. The mechanism requires the password to be set in the finish template (Preseed default finish).